### PR TITLE
HAS-1: Add pagination to search results

### DIFF
--- a/pages/p/_PageSlug.vue
+++ b/pages/p/_PageSlug.vue
@@ -145,7 +145,9 @@ export default Vue.extend({
       if (this.isSearchPage) {
         const searchQuery: string = this.$route.query.query as string
         articles = await new PhraseService({ vue: this }).searchPhrase({
-          searchQuery
+          searchQuery,
+          take: this.teaserCount,
+          skip
         })
         // Sort articles by publication date, newest first
         if (articles) {
@@ -172,9 +174,6 @@ export default Vue.extend({
       // archive page exception: subtract one page, because we set the second page as the first. thus, the last page has to be one bellow.
       if (this.isArchivePage && totalPages > 1) {
         totalPages -= 1
-      }
-      if (this.isSearchPage) {
-        totalPages = 1
       }
       this.pagination!.update({ totalPages })
       return articles


### PR DESCRIPTION
This change adds pagination to the search results. After changing the phrase backend to include pagination info (see [1]), less custom code for the search results page is required, while automatically benefitting from the existing code for the pagination. The behaviour is now more similar to the other collection pages like the archive and the category pages.

[1] https://github.com/wepublish/wepublish/pull/1312