### PR TITLE
HAS-16: Do not cut articles when visiting from a cafe

### DIFF
--- a/components/blocks/TeaserGridBlockView.vue
+++ b/components/blocks/TeaserGridBlockView.vue
@@ -199,6 +199,7 @@ import AuthorsLine from '~/components/author/AuthorsLine.vue'
 import ImgLoadingSlot from '~/sdk/wep/components/img/ImgLoadingSlot.vue'
 import PeerArticleTeaser from '~/sdk/wep/models/teaser/PeerArticleTeaser'
 import PeeringImgOverlay from '~/components/blocks/PeeringImgOverlay.vue'
+import { LoginBypass } from '~/sdk/wep/utils'
 
 export default Vue.extend({
   name: 'TeaserGridBlockView',
@@ -264,7 +265,8 @@ export default Vue.extend({
         // article id is for paywall purposes. see WepPublication.vue
         const baseUrl = `/a/${teaser?.wepPublication?.slug}`
         const hasAccess = this.$store.getters['auth/hasAccess']
-        return hasAccess ? baseUrl : `${baseUrl}?articleId=${teaser.wepPublication?.id}`
+        const loginBypass = (new LoginBypass(this.$cookies).check())
+        return (hasAccess || loginBypass) ? baseUrl : `${baseUrl}?articleId=${teaser.wepPublication?.id}`
       } else if (teaser.__typename === 'PageTeaser') {
         return `/p/${teaser?.wepPublication?.slug}`
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,6 +40,7 @@ import { MetaInfo } from 'vue-meta'
 import Page from '~/sdk/wep/models/wepPublication/page/Page'
 import PageService from '~/sdk/wep/services/PageService'
 import BlocksView from '~/components/blocks/BlocksView.vue'
+import { LoginBypass } from '~/sdk/wep/utils'
 
 export default Vue.extend({
   name: 'IndexPage',
@@ -84,6 +85,16 @@ export default Vue.extend({
   async beforeMount () {
     // fixes https://hauptstadt.atlassian.net/browse/HA-121
     await this.$vuetify.goTo(0, { duration: 0 })
+
+    const loginBypass = new LoginBypass(this.$cookies)
+    const enabled = loginBypass.enable(this.$route.query.key as string)
+
+    if (enabled) {
+      // remove 'key' query param
+      const query = Object.assign({}, this.$route.query);
+      delete query.key;
+      this.$router.replace({ query });
+    }
 
     const page = await this.loadPage()
     if (!page) {

--- a/sdk/wep/utils.ts
+++ b/sdk/wep/utils.ts
@@ -1,3 +1,32 @@
 export function stripHtml(input: string) {
   return input.replace(/(<([^>]+)>)/gi, '')
 }
+
+export class LoginBypass {
+  private COOKIE_NAME = 'cafe-key'
+  private VALID_KEYS = {
+    'DUMMY_CAFE': 'aed1dfa6dd5020ab7af56aebd2e5db68',
+  }
+
+  constructor(private $cookies: any) {}
+
+  enable(key: string): boolean {
+    if (!key || !this.valid(key)) {
+      return false
+    }
+    this.$cookies.set(this.COOKIE_NAME, key, {
+      path: '/',
+      maxAge: 60 * 60 * 4
+    })
+    return true
+  }
+
+  check(): boolean {
+    const cookie = this.$cookies.get(this.COOKIE_NAME)
+    return this.valid(cookie)
+  }
+
+  private valid(value: string): boolean {
+    return Object.values(this.VALID_KEYS).indexOf(value) > -1
+  }
+}


### PR DESCRIPTION
This change allows cafes to provide their guests with a secret key that allows them to read the entire article instead of cutting them off. The key is passed as a query param at the first visit and stored in a cookie, valid for 4 hours. When the cookie is set, the entire article is shown. The cookie is checked whenever a link to an article link is rendered.