### PR TITLE
WPC-1419: Fix search for multiple search terms

### DIFF
--- a/components/navigation/header/menu/MenuRubricEntries.vue
+++ b/components/navigation/header/menu/MenuRubricEntries.vue
@@ -75,8 +75,7 @@ export default Vue.extend({
       if (activeElement) {
         activeElement.blur()
       }
-      const preparedSearchQuery = this.searchQuery.replace(' ', ' & ')
-      const link = `/p/search?query=${preparedSearchQuery}`
+      const link = `/p/search?query=${this.searchQuery}`
       this.searchQuery = ''
       await this.$router.push(link)
       this.$store.commit('navigation/closeMenu')


### PR DESCRIPTION
When searching for multiple terms, the search should only match articles where all of the terms are present. This was changed in the frontend in https://hauptstadt.atlassian.net/browse/HA-176 and then later in the backend in https://wepublish.atlassian.net/browse/WPC-1419 by adding an ampersand. When both fixes are run, the search terms are broken and the search produces invalid SQL. This change removes the ampersand injection in the frontend.