### PR TITLE
HAS-16: Disable paywall even after navigation

### DIFF
--- a/components/blocks/TeaserGridBlockView.vue
+++ b/components/blocks/TeaserGridBlockView.vue
@@ -199,7 +199,6 @@ import AuthorsLine from '~/components/author/AuthorsLine.vue'
 import ImgLoadingSlot from '~/sdk/wep/components/img/ImgLoadingSlot.vue'
 import PeerArticleTeaser from '~/sdk/wep/models/teaser/PeerArticleTeaser'
 import PeeringImgOverlay from '~/components/blocks/PeeringImgOverlay.vue'
-import { LoginBypass } from '~/sdk/wep/utils'
 
 export default Vue.extend({
   name: 'TeaserGridBlockView',
@@ -265,8 +264,7 @@ export default Vue.extend({
         // article id is for paywall purposes. see WepPublication.vue
         const baseUrl = `/a/${teaser?.wepPublication?.slug}`
         const hasAccess = this.$store.getters['auth/hasAccess']
-        const loginBypass = (new LoginBypass(this.$cookies).check())
-        return (hasAccess || loginBypass) ? baseUrl : `${baseUrl}?articleId=${teaser.wepPublication?.id}`
+        return hasAccess ? baseUrl : `${baseUrl}?articleId=${teaser.wepPublication?.id}`
       } else if (teaser.__typename === 'PageTeaser') {
         return `/p/${teaser?.wepPublication?.slug}`
       }

--- a/components/wepPublication/WepPublication.vue
+++ b/components/wepPublication/WepPublication.vue
@@ -217,6 +217,7 @@ import PagePropertiesContent from '~/components/wepPublication/PagePropertiesCon
 import CrowdfundingBlock from '~/sdk/wep/models/block/CrowdfundingBlock'
 import UserInteractionOffline from '~/sdk/wep/components/helpers/UserInteractionOffline.vue'
 import TextZoom from '~/components/helpers/TextZoom.vue'
+import { LoginBypass } from '~/sdk/wep/utils'
 
 export default Vue.extend({
   name: 'WepPublication',
@@ -384,7 +385,8 @@ export default Vue.extend({
         startPath = currentPath
       }
       const paywallKey = this.$route.query.articleId
-      if (startPath !== currentPath || paywallKey) {
+      const loginBypass = (new LoginBypass(this.$cookies).check())
+      if ((startPath !== currentPath || paywallKey) && !loginBypass) {
         // apply paywall
         blocks?.removeBlocks(3)
         this.showPaywall = true


### PR DESCRIPTION
In commit 3767a3b4039ab4790c518474fe4946ca7ef55f01, a method to temporarily disable the paywall was added. When appending a secret key to the URL, the paywall was to be bypassed for 4 hours.

The change correctly removed the 'articleId' parameter from the URL when visiting an article, but failed to take into account, that there was a second condition for hiding the paywall, namely that no navigation must have occurred before visiting the article.

This change makes sure that the paywall is hidden, even when opening the home page and then navigating to the article.