### PR TITLE
SHARE-9: Add head.js and body.js scripts from the editor

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,6 +65,10 @@ export default {
       {rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png'},
       {rel: 'manifest', href: '/site.webmanifest'},
       {rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#000000'}
+    ],
+    script: [
+      { src: `${process.env.WEP_API_URL_CLIENT.replace('/v1', '')}/static/head.js` },
+      { src: `${process.env.WEP_API_URL_CLIENT.replace('/v1', '')}/static/body.js`, body: true },
     ]
   },
   publicRuntimeConfig: {


### PR DESCRIPTION
This change adds the head and body scripts hosted in the editor to the website. Since the WEP_API_URL_CLIENT environment voriable contains the trailing "/v1", it is removed when building the URL of the two scripts.