### PR TITLE
SHARE-9: Move script injection from nuxt config to layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -69,6 +69,14 @@ export default Vue.extend({
       overlay: false
     }
   },
+  head() {
+    return {
+      script: [
+        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/static/head.js` },
+        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/static/body.js`, body: true },
+      ]
+    }
+  },
   computed: {
     redirectUrl (): string | undefined {
       return this.$nuxt.context.$config.REDIRECT_URL

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,10 +65,6 @@ export default {
       {rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png'},
       {rel: 'manifest', href: '/site.webmanifest'},
       {rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#000000'}
-    ],
-    script: [
-      { src: `${process.env.WEP_API_URL_CLIENT.replace('/v1', '')}/static/head.js` },
-      { src: `${process.env.WEP_API_URL_CLIENT.replace('/v1', '')}/static/body.js`, body: true },
     ]
   },
   publicRuntimeConfig: {
@@ -97,7 +93,9 @@ export default {
     // HAS internal
     MEDIUM_SLUG: 'HAS'
   },
-  privateRuntimeConfig: {},
+  privateRuntimeConfig: {
+    WEP_API_URL_CLIENT: process.env.WEP_API_URL_CLIENT
+  },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [


### PR DESCRIPTION
Injecting the scripts inside the Nuxt config breaks the build of the application, because the environment variables are not availalble during build time. This change moves the configuration to the layout file, where the config is present.