### PR TITLE
SHARE-9: Change script path

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -72,8 +72,8 @@ export default Vue.extend({
   head() {
     return {
       script: [
-        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/static/head.js` },
-        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/static/body.js`, body: true },
+        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/scripts/head.js` },
+        { src: `${this.$nuxt.context.$config.WEP_API_URL_CLIENT.replace('/v1', '')}/scripts/body.js`, body: true },
       ]
     }
   },


### PR DESCRIPTION
After the changes introduced in
https://github.com/wepublish/wepublish/pull/1356/commits/02acd983ee9949ee0317c16343a4a1b84abb6a52, the path of the scripts hosted by the API needs to be updated.