### PR TITLE
HAS-25: Only remove ArticleID query parameter

### DIFF
--- a/components/wepPublication/WepPublication.vue
+++ b/components/wepPublication/WepPublication.vue
@@ -409,7 +409,9 @@ export default Vue.extend({
       this.publication.blocks?.revealRemovedBlocks()
       this.showPaywall = false
       // remove articleId param in case logged-in user want's to share the article with non-logged-in users
-      this.$router.replace(this.$route.path)
+      const currentQuery = { ...this.$route.query };
+      delete currentQuery.articleId;
+      this.$router.replace({ path: this.$route.path, query: currentQuery });
     },
     addPaywallBlock (paywalls: Paywalls): void {
       if (!this.paywallRulesGiven()) {


### PR DESCRIPTION
Removing all query parameters has the side effect, that the query text on the search page is removed as well, which breaks the search. This change only removes the articleId query parameter.