### PR TITLE
Add additional appID to apple-app-site-association for relocated iOS app

### DIFF
--- a/static/.well-known/apple-app-site-association
+++ b/static/.well-known/apple-app-site-association
@@ -4,6 +4,10 @@
       {
         "appID": "68X2T4YTGN.be.hauptstadt.ios",
         "paths": ["NOT /abo", "NOT /login/*invoiceId*", "/*"]
+      },
+      {
+        "appID": "432YL7M6PK.be.hauptstadt.ios",
+        "paths": ["NOT /abo", "NOT /login/*invoiceId*", "/*"]
       }
     ]
   }


### PR DESCRIPTION
In order for a web page to open in an app instead of the browser, the associated domain ownership must be proven via the apple-app-site-association file. After moving the app from Seccom to WePublish, the team id of the app has changed, requiring a new entry in the association file. This change adds the new identifier in a backwards compatible way, allowing both versions of the app to exist at the same time.